### PR TITLE
Fix using tipi for caching and when the user doesn't want SBOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cmake-tipi-provider: Automatic build caching for CMake FetchContent 
+# cmake-tipi-provider: Automatic build caching and SBOM generation for CMake FetchContent 
 **tipi.build ❤️ CMake**
 
 <img src="./assets/tipi.build%20logo.svg" witdth="100px" height="100px"/>

--- a/tipi_provider.cmake
+++ b/tipi_provider.cmake
@@ -79,16 +79,18 @@ macro(tipi_provide_dependency method package_name)
 
     endif()
     
-    sbom_add(
-      PACKAGE ${package_name}
-      DOWNLOAD_LOCATION ${ARG_GIT_REPOSITORY}
-      VERSION ${ARG_GIT_TAG}
-      #[EXTREF <ref>...]
-      #[LICENSE <string>]
-      #[RELATIONSHIP <string>]
-      #[SPDXID <id>]
-      #SUPPLIER Boost
-    )
+    if(NOT "${_sbom_project}" STREQUAL "")
+      sbom_add(
+        PACKAGE ${package_name}
+        DOWNLOAD_LOCATION ${ARG_GIT_REPOSITORY}
+        VERSION ${ARG_GIT_TAG}
+        #[EXTREF <ref>...]
+        #[LICENSE <string>]
+        #[RELATIONSHIP <string>]
+        #[SPDXID <id>]
+        #SUPPLIER Boost
+      )
+    endif()
 
     list(INSERT CMAKE_FIND_ROOT_PATH 0 "${ARG_SOURCE_DIR}/build/${POLLY_TOOLCHAIN_TAG}/installed" )
     list(APPEND CMAKE_PREFIX_PATH "${ARG_SOURCE_DIR}/build/${POLLY_TOOLCHAIN_TAG}/installed" )

--- a/tipi_provider.cmake
+++ b/tipi_provider.cmake
@@ -53,10 +53,8 @@ macro(tipi_provide_dependency method package_name)
       # which detects a recursive call for the same thing and avoids calling
       # the provider again if dep_name is the same as the current call.
       if(NOT ${package_name}_POPULATED)
-        message("**** About to call $ENV{CURRENT_TIPI_BINARY} ")
         # Fetch the content using previously declared details
         FetchContent_Populate(${package_name})
-        message("**** Calling $ENV{CURRENT_TIPI_BINARY} ")
         execute_process(
           COMMAND $ENV{CURRENT_TIPI_BINARY} -t ${POLLY_TOOLCHAIN_TAG} -u  --install .
           WORKING_DIRECTORY ${ARG_SOURCE_DIR}

--- a/tipi_provider.cmake
+++ b/tipi_provider.cmake
@@ -53,8 +53,10 @@ macro(tipi_provide_dependency method package_name)
       # which detects a recursive call for the same thing and avoids calling
       # the provider again if dep_name is the same as the current call.
       if(NOT ${package_name}_POPULATED)
+        message("**** About to call $ENV{CURRENT_TIPI_BINARY} ")
         # Fetch the content using previously declared details
         FetchContent_Populate(${package_name})
+        message("**** Calling $ENV{CURRENT_TIPI_BINARY} ")
         execute_process(
           COMMAND $ENV{CURRENT_TIPI_BINARY} -t ${POLLY_TOOLCHAIN_TAG} -u  --install .
           WORKING_DIRECTORY ${ARG_SOURCE_DIR}

--- a/tipi_provider.cmake
+++ b/tipi_provider.cmake
@@ -63,6 +63,7 @@ macro(tipi_provide_dependency method package_name)
           RESULT_VARIABLE error_building
           ECHO_OUTPUT_VARIABLE
           ECHO_ERROR_VARIABLE
+          COMMAND_ERROR_IS_FATAL ANY
           )
       
         if (NOT error_building)


### PR DESCRIPTION
This fixes 2 things : 
- users that don't want to generate SBOM can use the automatic cache ( no need to call `sbom_generate`)
- more critically fails if it is unable to find tipi 
